### PR TITLE
Respect calibration of input image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>Stack_Manipulation</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 
 	<name>Stack Manipulation</name>
 	<description>Stack Manipulation plugin for Fiji.</description>
@@ -79,6 +79,11 @@
 			<name>Mark Hiner</name>
 			<url>http://imagej.net/User:Hinerm</url>
 			<properties><id>hinerm</id></properties>
+		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>http://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
 		</contributor>
 	</contributors>
 

--- a/src/main/java/Slice_Keeper.java
+++ b/src/main/java/Slice_Keeper.java
@@ -3,6 +3,7 @@ import ij.ImagePlus;
 import ij.ImageStack;
 import ij.WindowManager;
 import ij.gui.GenericDialog;
+import ij.measure.Calibration;
 import ij.plugin.PlugIn;
 import ij.process.ImageProcessor;
 
@@ -12,6 +13,8 @@ public class Slice_Keeper implements PlugIn {
 	private static int last = 9999;
 	private static int inc = 2;
 	String title;
+
+	@Override
 	public void run(String arg) {
 		ImagePlus imp = WindowManager.getCurrentImage();
 		if (imp==null)
@@ -22,7 +25,7 @@ public class Slice_Keeper implements PlugIn {
 		if (!showDialog(stack))
 			return;
 		title=imp.getTitle();
-		keepSlices(stack, first, last, inc);
+		keepSlices(stack, first, last, inc, imp.getCalibration());
 		//imp.setStack(null, stack);
 		IJ.register(Slice_Keeper.class);
 	}
@@ -44,6 +47,10 @@ public class Slice_Keeper implements PlugIn {
 	}
 
 	public void keepSlices(ImageStack stack, int first, int last, int inc) {
+		keepSlices(stack, first, last, inc, null);
+	}
+
+	public void keepSlices(ImageStack stack, int first, int last, int inc, Calibration cal) {
 		if (last>stack.getSize())
 		last = stack.getSize();
 
@@ -60,7 +67,13 @@ public class Slice_Keeper implements PlugIn {
 			newstack.addSlice("slice:" + i, ip);
 			count++;
 			}
-		new ImagePlus(title+" kept stack", newstack).show();
+		
+		ImagePlus imp = new ImagePlus(title+" kept stack", newstack);
+		if (cal != null) {
+			cal.pixelDepth = cal.pixelDepth * inc;
+			imp.setCalibration(cal);
+		}
+		imp.show();	
 	}
 
 }


### PR DESCRIPTION
This adds a new overloaded `keepSlices()` method with a new `Calibration` parameter. The old one is kept for backwards compatibility.

See [this report](http://forum.imagej.net/t/slice-keeper-causes-downsampling/5181?u=imagejan) on the forum.